### PR TITLE
make cli-config compatible with 2.4.x

### DIFF
--- a/cli-config.php
+++ b/cli-config.php
@@ -5,3 +5,5 @@ require_once "bootstrap.php";
 $helperSet = new \Symfony\Component\Console\Helper\HelperSet(array(
     'em' => new \Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper($entityManager)
 ));
+
+return $helperSet;


### PR DESCRIPTION
1. composer now installs doctrine 2.4.x
2. vendor/bin/doctrine throws an error about $helperSet
3. apparently it wants the cli-config.php to return the $helperSet, see https://github.com/doctrine/doctrine2/commit/a7d764f6c07c6d7cb07fc4ccf7447e14a90ca569
