### PR TITLE
Exit if product id is invalid

### DIFF
--- a/create_bug.php
+++ b/create_bug.php
@@ -20,6 +20,10 @@ $bug->setStatus("OPEN");
 
 foreach ($productIds AS $productId) {
     $product = $entityManager->find("Product", $productId);
+    if (!$product) {
+        echo "No product found for the input.\n";
+        exit(1);
+    }
     $bug->assignToProduct($product);
 }
 


### PR DESCRIPTION
If the reader uses these command:
$ php vendor/bin/doctrine orm:schema-tool:drop --force
$ php vendor/bin/doctrine orm:schema-tool:create
for recreating database, create_bug.php will fail because all products are cleared.
