### PR TITLE
Fixed comments to refer to the correct methods

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -3,12 +3,12 @@ use Doctrine\ORM\Tools\Setup;
 
 require_once "vendor/autoload.php";
 
-// Create a simple "default" Doctrine ORM configuration for XML Mapping
+// Create a simple "default" Doctrine ORM configuration for Annotation Mapping
 $isDevMode = true;
 $config = Setup::createAnnotationMetadataConfiguration(array(__DIR__."/src"), $isDevMode);
-// or if you prefer yaml or annotations
-//$config = Setup::createXMLMetadataConfiguration(array(__DIR__."/config/xml"), $isDevMode);
+// or if you prefer yaml or XML
 //$config = Setup::createYAMLMetadataConfiguration(array(__DIR__."/config/yaml"), $isDevMode);
+//$config = Setup::createXMLMetadataConfiguration(array(__DIR__."/config/xml"), $isDevMode);
 
 // database configuration parameters
 $conn = array(


### PR DESCRIPTION
Comments in the bootstrap.php refer to the wrong methods.
